### PR TITLE
Simplified the ScrambleTeam method

### DIFF
--- a/src/TeamScrambler.cs
+++ b/src/TeamScrambler.cs
@@ -71,7 +71,7 @@ public class TeamScrambler
 
         // Swap to team Blue starting with the largest indexed Red player to preserve ordering
         List<int> swapToBlueList = new List<int>(swapToBlue.ToArray());
-        swapToBlueList.Sort((a, b) => -1*a.CompareTo(b));
+        swapToBlueList.Sort(Comparer<int>.Default);
         while (swapToBlueList.Count > 1)
         {
             int index = swapToBlue.Count - 1;

--- a/src/TeamScrambler.cs
+++ b/src/TeamScrambler.cs
@@ -27,8 +27,9 @@ public class TeamScrambler
         _bots.RemoveBots();
         Thread.Sleep(2000);
 
-        int redCount = _cg.RedCount;
-        int playerCount = redCount + _cg.BlueCount;
+        int redCount  = _cg.RedCount;
+        int blueCount = _cg.BlueCount;
+        int playerCount = redCount + blueCount;
 
         // List the players randomly
         var distribution = new List<Tuple<float, int>>(playerCount);
@@ -52,6 +53,20 @@ public class TeamScrambler
 
             _cg.Interact.Move(player1, player2);
         }
+
+        // teams were already balanced
+        if (redCount == blueCount)
+            return;
+
+        // exchange the last player to the team with less players
+        int oddPlayer = distribution[playerCount - 1].Item2;
+        Team otherTeam;
+        if (redCount > blueCount)
+            otherTeam = Team.Blue;
+        else
+            otherTeam = Team.Red;
+
+        _manipulation.SwapWithEmpty(oddPlayer, otherTeam);
     }
 
     public void SwapIfImbalance()

--- a/src/TeamScrambler.cs
+++ b/src/TeamScrambler.cs
@@ -54,19 +54,19 @@ public class TeamScrambler
             _cg.Interact.Move(player1, player2);
         }
 
-        // teams were already balanced
+        // Check if teams were balanced
         if (redCount == blueCount)
             return;
 
-        // exchange the last player to the team with less players
+        // Exchange the odd player out on the list to the team with less players
         int oddPlayer = distribution[playerCount - 1].Item2;
-        Team otherTeam;
+        Team smallerTeam;
         if (redCount > blueCount)
-            otherTeam = Team.Blue;
+            smallerTeam = Team.Blue;
         else
-            otherTeam = Team.Red;
+            smallerTeam = Team.Red;
 
-        _manipulation.SwapWithEmpty(oddPlayer, otherTeam);
+        _manipulation.SwapWithEmpty(oddPlayer, smallerTeam);
     }
 
     public void SwapIfImbalance()


### PR DESCRIPTION
Adjusted the procedures to be more linear and compact. Teams are decided before swapping, and each player is only checked once, avoiding swapping the same player twice.